### PR TITLE
PDS-1186 fix test logger

### DIFF
--- a/src/TestLogger.php
+++ b/src/TestLogger.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Humi\StructuredLogger\Tests;
+namespace Humi\StructuredLogger;
 
 use Psr\Log\AbstractLogger;
 

--- a/tests/DataChangeLoggingServiceTest.php
+++ b/tests/DataChangeLoggingServiceTest.php
@@ -4,6 +4,7 @@ namespace Humi\StructuredLogger\Tests;
 
 use Humi\StructuredLogger\DataChangeLoggingService;
 use Humi\StructuredLogger\LogTypes;
+use Humi\StructuredLogger\TestLogger;
 use PHPUnit\Framework\TestCase;
 
 class DataChangeLoggingServiceTest extends TestCase


### PR DESCRIPTION
# Pull Request

## Why is this change needed

I moved the TestLogger to `tests`, but it was a bad idea because we use the `TestLogger` in our HR app's tests.
