### PR TITLE
PDS-1182 add data change id and type to root

### DIFF
--- a/src/StructuredLogFormatter.php
+++ b/src/StructuredLogFormatter.php
@@ -60,6 +60,8 @@ class StructuredLogFormatter implements FormatterInterface
         $formattedRecord['causer_id'] = $this->getCauserID();
         $formattedRecord['causer_type'] = $this->getCauserType();
         $formattedRecord['context'] = $record['context'];
+        $formattedRecord['data_id'] = $this->getDataId($record);
+        $formattedRecord['data_type'] = $this->getDataType($record);
         $formattedRecord['datetime'] = Carbon::parse($record['datetime'])->toISOString();
         $formattedRecord['delta'] = $this->getDelta($record);
         $formattedRecord['env'] = $this->getEnvironment();
@@ -196,7 +198,35 @@ class StructuredLogFormatter implements FormatterInterface
     }
 
     /**
-     *  getType determines the type of the log record.
+     * getDataId will return an id associated with a data change
+     * if this record is not a data change record, it will return an empty string
+     *
+     * the return type is a string in the anticipation that ids could be non numeric
+     */
+    protected function getDataId(array $record): string
+    {
+        if (!$this->isDataChange($record)){
+            return '';
+        }
+
+        return (string) $record['context'][LogTypes::DATA_CHANGED]['data_id'];
+    }
+
+    /**
+     * getDataType will return a type associated with a data change
+     * if this record is not a data change record, it will return an empty string
+     */
+    protected function getDataType(array $record): string
+    {
+        if (!$this->isDataChange($record)){
+            return '';
+        }
+
+        return $record['context'][LogTypes::DATA_CHANGED]['data_type'];
+    }
+
+    /**
+     * getType determines the type of the log record.
      */
     protected function getType(array $record): string
     {
@@ -274,5 +304,10 @@ class StructuredLogFormatter implements FormatterInterface
     protected function getEnvironment(): ?string
     {
         return null;
+    }
+
+    protected function isDataChange(array $record): bool
+    {
+        return Arr::exists($record['context'], LogTypes::DATA_CHANGED);
     }
 }

--- a/tests/StructuredLogFormatterTest.php
+++ b/tests/StructuredLogFormatterTest.php
@@ -76,11 +76,54 @@ class StructuredLogFormatterTest extends TestCase
             'datetime' => '2021-03-29',
             'level_name' => 'INFO',
             'message' => 'Some message',
-            'context' => ['data_changed' => []],
+            'context' => ['data_changed' => [
+                'data_id' => 123,
+                'data_type' => 'SOME\TYPE'
+              ]
+            ],
         ];
 
         $formattedRecord = $formatter->format($record);
 
         $this->assertSame(LogTypes::DATA_CHANGED, $formattedRecord['type']);
+    }
+
+    /** @test */
+    public function it_sets_the_data_type_and_id_only_when_one_exists(): void
+    {
+        /**
+         * @var StructuredLogFormatter $formatter
+         */
+        $formatter = new StructuredLogFormatter();
+
+        $record = [
+            'level' => Logger::INFO,
+            'datetime' => '2021-03-29',
+            'level_name' => 'INFO',
+            'message' => 'Some message',
+            'context' => [],
+        ];
+
+        $formattedRecord = $formatter->format($record);
+
+        $this->assertSame('', $formattedRecord['data_id']);
+        $this->assertSame('', $formattedRecord['data_type']);
+
+        $record = [
+            'level' => Logger::INFO,
+            'datetime' => '2021-03-29',
+            'level_name' => 'INFO',
+            'message' => 'Some message',
+            'context' => ['data_changed' => [
+                'data_id' => 123,
+                'data_type' => 'SOME\TYPE'
+              ]
+            ],
+        ];
+
+        $formattedRecord = $formatter->format($record);
+
+        $this->assertSame('123', $formattedRecord['data_id']);
+        $this->assertSame('SOME\TYPE', $formattedRecord['data_type']);
     }
 }


### PR DESCRIPTION
# Pull Request

[Jira link](https://gethumi.atlassian.net/browse/PDS-1182)

## Why is this change needed

We want to be able to index data_id and data_type.
We can't do this if they only live in context because context will not be indexed.

## What changes were made

Adds data_id and data_type to the root of the log object.

## How was it tested

Unit test

## What are the implications (Optional)

This won't go "live" until HR starts using this version of the logger.
