### PR TITLE
Fix: Closures are not supported in config files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor
 node_modules
+.idea/
 .phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ This is an example of configuration for the HR app found in `/config/logging.php
         'structured' => [
             'driver' => 'monolog',
             'handler' => HRStructuredLogHandler::class, // use your extended handler
+            'formatter' => HRStructuredLogFormatter::class,
             'with' => [
                 'stream' => storage_path('logs/structured.log'),
-                'formatter' => app(HRStructuredLogFormatter::class), // use your extended formatter
             ],
         ],
     ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "php-structured-logger",
+  "name": "structured-logger",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/src/StructuredLogHandler.php
+++ b/src/StructuredLogHandler.php
@@ -5,6 +5,8 @@ namespace Humi\StructuredLogger;
 use Monolog\Formatter\FormatterInterface;
 use Monolog\Formatter\JsonFormatter;
 use Monolog\Handler\AbstractHandler;
+use Monolog\Handler\FormattableHandlerInterface;
+use Monolog\Handler\HandlerInterface;
 use Monolog\Handler\StreamHandler;
 use Monolog\Logger;
 
@@ -20,7 +22,7 @@ use Monolog\Logger;
  * @see https://github.com/Seldaek/monolog
  * @see https://laravel.com/docs/8.x/logging
  */
-class StructuredLogHandler extends AbstractHandler
+class StructuredLogHandler extends AbstractHandler implements FormattableHandlerInterface
 {
     private array $records = [];
     private StreamHandler $streamHandler;
@@ -31,7 +33,6 @@ class StructuredLogHandler extends AbstractHandler
      */
     public function __construct(
         $stream,
-        FormatterInterface $formatter,
         $level = Logger::DEBUG,
         bool $bubble = true,
         ?int $filePermission = null,
@@ -41,8 +42,6 @@ class StructuredLogHandler extends AbstractHandler
 
         $this->streamHandler = new StreamHandler($stream, $level, $bubble, $filePermission, $useLocking);
         $this->streamHandler->setFormatter(new JsonFormatter());
-
-        $this->formatter = $formatter;
     }
 
     public function handle(array $record): bool
@@ -81,6 +80,28 @@ class StructuredLogHandler extends AbstractHandler
      */
     private function format(): void
     {
-        $this->records = $this->formatter->formatBatch($this->records);
+        $this->records = $this->getFormatter()->formatBatch($this->records);
+    }
+
+    /**
+     * Sets the formatter.
+     */
+    public function setFormatter(FormatterInterface $formatter): HandlerInterface
+    {
+        $this->formatter = $formatter;
+
+        return $this;
+    }
+
+    /**
+     * Gets the formatter.
+     */
+    public function getFormatter(): FormatterInterface
+    {
+        if (!isset($this->formatter)) {
+            throw new \LogicException('No formatter has been set and this handler does not have a default formatter');
+        }
+
+        return $this->formatter;
     }
 }

--- a/src/StructuredLogHandler.php
+++ b/src/StructuredLogHandler.php
@@ -99,7 +99,7 @@ class StructuredLogHandler extends AbstractHandler implements FormattableHandler
     public function getFormatter(): FormatterInterface
     {
         if (!isset($this->formatter)) {
-            throw new \LogicException('No formatter has been set and this handler does not have a default formatter');
+            $this->formatter = new StructuredLogFormatter(); // Fallback to our default formatter
         }
 
         return $this->formatter;

--- a/tests/StructuredLogHandlerTest.php
+++ b/tests/StructuredLogHandlerTest.php
@@ -13,7 +13,8 @@ class StructuredLogHandlerTest extends TestCase
     public function it_handles_when_the_log_level_is_equal_to_threshold(): void
     {
         $stream = fopen('php://temp', 'r');
-        $handler = new StructuredLogHandler($stream, new LineFormatter(), Logger::DEBUG, false);
+        $handler = new StructuredLogHandler($stream, Logger::DEBUG, false);
+        $handler->setFormatter(new LineFormatter());
 
         $this->assertTrue($handler->handle(['level' => Logger::DEBUG]));
     }
@@ -22,7 +23,8 @@ class StructuredLogHandlerTest extends TestCase
     public function it_handles_when_the_log_level_is_above_threshold(): void
     {
         $stream = fopen('php://temp', 'r');
-        $handler = new StructuredLogHandler($stream, new LineFormatter(), Logger::DEBUG, false);
+        $handler = new StructuredLogHandler($stream, Logger::DEBUG, false);
+        $handler->setFormatter(new LineFormatter());
 
         $this->assertTrue($handler->handle(['level' => Logger::EMERGENCY]));
     }
@@ -31,8 +33,21 @@ class StructuredLogHandlerTest extends TestCase
     public function it_does_not_handle_when_the_log_level_is_below_threshold(): void
     {
         $stream = fopen('php://temp', 'r');
-        $handler = new StructuredLogHandler($stream, new LineFormatter(), Logger::INFO, false);
+        $handler = new StructuredLogHandler($stream, Logger::INFO, false);
+        $handler->setFormatter(new LineFormatter());
 
         $this->assertFalse($handler->handle(['level' => Logger::DEBUG]));
+    }
+
+    /** @test */
+    public function it_throws_an_exception_when_no_formatter(): void
+    {
+        $stream = fopen('php://temp', 'r');
+        $handler = new StructuredLogHandler($stream, Logger::INFO, false);
+
+        $this->expectException(\LogicException::class);
+
+        $handler->handle(['level' => Logger::DEBUG]);
+        $handler->close();
     }
 }

--- a/tests/StructuredLogHandlerTest.php
+++ b/tests/StructuredLogHandlerTest.php
@@ -2,6 +2,7 @@
 
 namespace Humi\StructuredLogger\Tests;
 
+use Humi\StructuredLogger\StructuredLogFormatter;
 use Humi\StructuredLogger\StructuredLogHandler;
 use PHPUnit\Framework\TestCase;
 use Monolog\Formatter\LineFormatter;
@@ -40,14 +41,12 @@ class StructuredLogHandlerTest extends TestCase
     }
 
     /** @test */
-    public function it_throws_an_exception_when_no_formatter(): void
+    public function it_uses_our_default_when_no_formatter_is_set(): void
     {
         $stream = fopen('php://temp', 'r');
-        $handler = new StructuredLogHandler($stream, Logger::INFO, false);
+        $handler = new StructuredLogHandler($stream, Logger::DEBUG, false);
 
-        $this->expectException(\LogicException::class);
-
-        $handler->handle(['level' => Logger::DEBUG]);
-        $handler->close();
+        $this->assertTrue($handler->handle(['level' => Logger::DEBUG]));
+        $this->assertInstanceOf(StructuredLogFormatter::class, $handler->getFormatter());
     }
 }


### PR DESCRIPTION
# Pull Request

## Why is this change needed

Laravel doesn’t support closures in config files.

You can see the problem if you try to run `artisan config:cache`

Example issue: https://github.com/laravel/framework/issues/9625

## What changes were made

Changed the logger to be more in line with Laravel 8 config to fix it: https://laravel.com/docs/8.x/logging#monolog-formatters

## How was it tested

Unit tests. Manually on my local.

## What are the implications (Optional)

We are still pre v1, so breaking changes are welcome, I hope. 😅 
