### PR TITLE
PDS-1233 attributes not to obfuscate

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,16 @@ protected array $attributesToObfuscateForLogging = ['sin_number', 'home_address'
 
 These fields will now be obfuscated in our logs.
 
+If instead you want to specify only the attributes not to obfuscate, create an instance variable called `attributesNotToObfuscateForLogging` on the model, and set its value to an array of keys. All other values will be obfuscated.
+
+Some model:
+
+```php
+protected array $attributesNotToObfuscateForLogging = ['favorite_food'];
+```
+
+Do not set both `$attributesToObfuscateForLogging` and `$attributesNotToObfuscateForLogging`. Choose one or the other.
+
 ### Dynamic attribute obfuscation
 
 There may be times that we want to obfuscate an attribute only if certain conditions are true.

--- a/src/DataChangeLoggingService.php
+++ b/src/DataChangeLoggingService.php
@@ -91,8 +91,10 @@ class DataChangeLoggingService
      */
     private function obfuscateValues(array $attributes, array $attributesToObfuscate): array
     {
+        $obfuscateMap = array_flip($attributesToObfuscate);
+
         foreach ($attributes as $key => $_) {
-            if (in_array($key, $attributesToObfuscate)) {
+            if (array_key_exists($key, $obfuscateMap)) {
                 $attributes[$key] = self::OBFUSCATED_VALUE;
             }
         }

--- a/src/Laravel/LogsDataChanges.php
+++ b/src/Laravel/LogsDataChanges.php
@@ -3,17 +3,13 @@
 namespace Humi\StructuredLogger\Laravel;
 
 /**
- * LogsDataChanges is an implementation of DataChangeLoggable
- * that works for Eloquent models.
+ * LogsDataChanges is an implementation of DataChangeLoggable that works for Eloquent models.
  *
  * @see Humi\StructuredLogger\DataChangeLoggable
  */
 trait LogsDataChanges
 {
-    /**
-     * attributesToObfuscateForLogging is a list of keys whose values will be obfuscated.
-     */
-    protected array $attributesToObfuscateForLogging = [];
+    protected array $attributesToNeverObfuscate = ['id', 'created_at', 'updated_at', 'deleted_at'];
 
     public function getIdForLogging(): string
     {
@@ -27,7 +23,17 @@ trait LogsDataChanges
 
     public function getAttributeNamesToObfuscateForLogging(): array
     {
-        return $this->attributesToObfuscateForLogging;
+        $attributesToObfuscate = [];
+
+        if (isset($this->attributesToObfuscateForLogging)) {
+            $attributesToObfuscate = array_merge($attributesToObfuscate, $this->getAttributesToObfuscateWhenPositive());
+        }
+
+        if (isset($this->attributesNotToObfuscateForLogging)) {
+            $attributesToObfuscate = array_merge($attributesToObfuscate, $this->getAttributesToObfuscateWhenNegative());
+        }
+
+        return array_values(array_unique($attributesToObfuscate));
     }
 
     public function getAttributesForLogging(): array
@@ -50,5 +56,40 @@ trait LogsDataChanges
     public function getChangedAttributesForLogging(): array
     {
         return $this->getChanges();
+    }
+
+    /**
+     * getAttributesToObfuscateWhenPositive gets attributes for when the user has specified $attributesToObfuscateForLogging
+     */
+    private function getAttributesToObfuscateWhenPositive(): array
+    {
+        $attrToObfuscate = $this->attributesToObfuscateForLogging;
+        $neverObfuscateMap = array_flip($this->attributesToNeverObfuscate);
+
+        // remove attributes that should never be obfuscated
+        $attrToObfuscate = array_filter($attrToObfuscate, fn($attr) => !array_key_exists($attr, $neverObfuscateMap));
+
+        // remove attributes that are not actually attributes on this object
+        $attrToObfuscate = array_filter($attrToObfuscate, fn($attr) => array_key_exists($attr, $this->getAttributes()));
+
+        return array_values($attrToObfuscate);
+    }
+
+    /**
+     * getAttributesToObfuscateWhenNegative gets attributes for when the user has specified $attributesNotToObfuscateForLogging
+     */
+    private function getAttributesToObfuscateWhenNegative(): array
+    {
+        $neverObfuscateMap = array_flip($this->attributesToNeverObfuscate);
+        $notObfuscateMap = array_flip($this->attributesNotToObfuscateForLogging);
+        $attrToObfuscate = [];
+
+        foreach ($this->getAttributes() as $attr => $_) {
+            if (!array_key_exists($attr, $neverObfuscateMap) && !array_key_exists($attr, $notObfuscateMap)) {
+                $attrToObfuscate[] = $attr;
+            }
+        }
+
+        return $attrToObfuscate;
     }
 }

--- a/tests/DataChangeLoggingServiceTest.php
+++ b/tests/DataChangeLoggingServiceTest.php
@@ -5,7 +5,6 @@ namespace Humi\StructuredLogger\Tests;
 use Humi\StructuredLogger\DataChangeLoggingService;
 use Humi\StructuredLogger\LogTypes;
 use Humi\StructuredLogger\TestLogger;
-use Humi\StructuredLogger\Tests\MockModel;
 use PHPUnit\Framework\TestCase;
 
 class DataChangeLoggingServiceTest extends TestCase

--- a/tests/Laravel/LogsDataChangesTest.php
+++ b/tests/Laravel/LogsDataChangesTest.php
@@ -66,7 +66,6 @@ class LogsDataChangesTest extends TestCase
         $this->attributesToObfuscateForLogging = ['age', 'weight'];
         $this->attributesNotToObfuscateForLogging = ['favoriteFood'];
 
-        /* dd($this->getAttributeNamesToObfuscateForLogging()); */
         $this->assertSame(['age', 'weight', 'name'], $this->getAttributeNamesToObfuscateForLogging());
     }
 

--- a/tests/Laravel/LogsDataChangesTest.php
+++ b/tests/Laravel/LogsDataChangesTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace Humi\StructuredLogger\Tests\Laravel;
+
+use Humi\StructuredLogger\Laravel\LogsDataChanges;
+use PHPUnit\Framework\TestCase;
+
+class LogsDataChangesTest extends TestCase
+{
+    // We are testing this trait by using it on the test class.
+    use LogsDataChanges;
+
+    private array $attributes = [
+        'id' => 123,
+        'name' => 'Harriet',
+        'favoriteFood' => 'lasagna',
+        'age' => 33,
+        'weight' => 150,
+        'created_at' => 'yesterday',
+        'updated_at' => 'today',
+        'deleted_at' => null,
+    ];
+
+    /** @test */
+    public function it_returns_an_empty_when_no_attributes_to_obfuscate_are_set(): void
+    {
+        $this->assertCount(0, $this->getAttributeNamesToObfuscateForLogging());
+    }
+
+    /** @test */
+    public function it_returns_attributes_to_obfuscate_when_set(): void
+    {
+        $this->attributesToObfuscateForLogging = ['age', 'weight'];
+
+        $this->assertSame(['age', 'weight'], $this->getAttributeNamesToObfuscateForLogging());
+    }
+
+    /** @test */
+    public function it_does_not_obfuscate_certain_attributes_even_when_asked_to(): void
+    {
+        $this->attributesToObfuscateForLogging = $this->attributesToNeverObfuscate;
+        $this->attributesToObfuscateForLogging[] = 'age';
+
+        $this->assertSame(['age'], $this->getAttributeNamesToObfuscateForLogging());
+    }
+
+    /** @test */
+    public function it_returns_attributes_to_obfuscate_when_attributes_not_to_obfuscate_are_set(): void
+    {
+        $this->attributesNotToObfuscateForLogging = ['name'];
+
+        $this->assertSame(['favoriteFood', 'age', 'weight'], $this->getAttributeNamesToObfuscateForLogging());
+    }
+
+    /** @test */
+    public function it_returns_attributes_to_obfuscate_when_attributes_not_to_obfuscate_is_set_to_an_empty_array(): void
+    {
+        $this->attributesNotToObfuscateForLogging = [];
+
+        $this->assertSame(['name', 'favoriteFood', 'age', 'weight'], $this->getAttributeNamesToObfuscateForLogging());
+    }
+
+    /** @test */
+    public function when_both_attributes_to_obfuscate_and_attributes_not_to_obfuscate_are_set_it_obfuscates_both(): void
+    {
+        $this->attributesToObfuscateForLogging = ['age', 'weight'];
+        $this->attributesNotToObfuscateForLogging = ['favoriteFood'];
+
+        /* dd($this->getAttributeNamesToObfuscateForLogging()); */
+        $this->assertSame(['age', 'weight', 'name'], $this->getAttributeNamesToObfuscateForLogging());
+    }
+
+    /**
+     * getAttributes is used by the trait
+     */
+    protected function getAttributes()
+    {
+        return $this->attributes;
+    }
+}


### PR DESCRIPTION
# Pull Request

[Jira link](https://gethumi.atlassian.net/browse/PDS-1233)

## Why is this change needed

Updates logger with better handling for `$attributesToObfuscateForLogging` and `$attributesNotToObfuscateForLogging`.

## What changes were made

Added tests to trait. 🤭
Handle `$attributesNotToObfuscateForLogging = [];`
Update README
Opitimizations using array_flip

## How was it tested

Unit tests.
