### PR TITLE
PDS-1247 update process_id to trace_id

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "structured-logger",
+  "name": "php-structured-logger",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {


### PR DESCRIPTION
# Pull Request

[Jira link](https://gethumi.atlassian.net/browse/PDS-1247)

## Why is this change needed

We want to use trace_id instead of process_id, and source it from the header when it exists.

## What changes were made

change process_id to trace_id
add logic for fetching the trace_id

## How was it tested

Formatter test
